### PR TITLE
remove purge-css from build

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -15,16 +15,16 @@ module.exports = function(defaults) {
   console.log(plugins)
 
   if (EmberApp.env() === 'production') {
-    plugins.push({
-        module: require('@fullhuman/postcss-purgecss'),
-        options: [
-          join(__dirname, 'app', 'index.html'),
-          join(__dirname, 'app', '**', '*.js'),
-          join(__dirname, 'app', '**', '*.hbs'),
-        ],
-        defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || [],
-        whitelistPattern: [/^_/],
-    });
+    // plugins.push({
+    //     module: require('@fullhuman/postcss-purgecss'),
+    //     options: [
+    //       join(__dirname, 'app', 'index.html'),
+    //       join(__dirname, 'app', '**', '*.js'),
+    //       join(__dirname, 'app', '**', '*.hbs'),
+    //     ],
+    //     defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || [],
+    //     whitelistPattern: [/^_/],
+    // });
   }
 
   const tailwindNode = compilePostCSS(


### PR DESCRIPTION
removing purge-css from ember-cli-build in an attempt to fix tailwind style issue